### PR TITLE
Potential fix for code scanning alert no. 22: For loop variable changed in body

### DIFF
--- a/rapidyenc/rapidyenc/src/decoder.cc
+++ b/rapidyenc/rapidyenc/src/decoder.cc
@@ -222,7 +222,7 @@ static RapidYenc::YencDecoderEnd do_decode_end_scalar(const unsigned char** src,
 	} else // treat as YDEC_STATE_CRLF
 		goto do_decode_endable_scalar_c0;
 	
-	for(; i < -2; i++) {
+	while (i < -2) {
 		c = es[i];
 		switch(c) {
 			case '\r': if(es[i+1] == '\n') {
@@ -283,6 +283,7 @@ static RapidYenc::YencDecoderEnd do_decode_end_scalar(const unsigned char** src,
 			default:
 				*p++ = c - 42;
 		}
+		i++;
 	}
 	if(state) *state = YDEC_STATE_NONE;
 	


### PR DESCRIPTION
Potential fix for [https://github.com/go-while/NZBreX/security/code-scanning/22](https://github.com/go-while/NZBreX/security/code-scanning/22)

To fix the issue, the `for` loop should be replaced with a `while` loop. This allows the loop counter (`i`) to be modified explicitly within the loop body without violating the expectations of a `for` loop. The loop condition (`i < -2`) will be preserved, and the initialization of `i` will be moved outside the loop. The increment expression (`i++`) in the `for` loop header will be removed, and all modifications to `i` within the loop body will remain unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
