### PR TITLE
Potential fix for code scanning alert no. 24: For loop variable changed in body

### DIFF
--- a/rapidyenc/rapidyenc/src/decoder.cc
+++ b/rapidyenc/rapidyenc/src/decoder.cc
@@ -222,7 +222,7 @@ static RapidYenc::YencDecoderEnd do_decode_end_scalar(const unsigned char** src,
 	} else // treat as YDEC_STATE_CRLF
 		goto do_decode_endable_scalar_c0;
 	
-	for(; i < -2; i++) {
+	while (i < -2) {
 		c = es[i];
 		switch(c) {
 			case '\r': if(es[i+1] == '\n') {


### PR DESCRIPTION
Potential fix for [https://github.com/go-while/NZBreX/security/code-scanning/24](https://github.com/go-while/NZBreX/security/code-scanning/24)

To address the issue, the `for` loop on line 225 should be replaced with a `while` loop. This change will make it clear that the loop counter `i` is modified within the loop body, aligning with the expectations for `while` loops. The loop condition (`i < -2`) will be preserved, and the initialization of `i` will be moved outside the loop. The loop increment expression (`i++`) will be removed, as the loop counter is already modified within the loop body.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
