### PR TITLE
Potential fix for code scanning alert no. 27: For loop variable changed in body

### DIFF
--- a/rapidyenc/rapidyenc/src/decoder.cc
+++ b/rapidyenc/rapidyenc/src/decoder.cc
@@ -222,7 +222,7 @@ static RapidYenc::YencDecoderEnd do_decode_end_scalar(const unsigned char** src,
 	} else // treat as YDEC_STATE_CRLF
 		goto do_decode_endable_scalar_c0;
 	
-	for(; i < -2; i++) {
+	while(i < -2) {
 		c = es[i];
 		switch(c) {
 			case '\r': if(es[i+1] == '\n') {


### PR DESCRIPTION
Potential fix for [https://github.com/go-while/NZBreX/security/code-scanning/27](https://github.com/go-while/NZBreX/security/code-scanning/27)

To fix the issue, the `for` loop should be replaced with a `while` loop. This will make it clear that the loop counter `i` is being modified within the loop body and is not solely controlled by the loop's increment expression. The loop condition (`i < -2`) will be moved to the `while` statement, and the initialization of `i` will remain outside the loop. The loop increment expression will be removed, as `i` is already being modified within the loop body.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
