### PR TITLE
Potential fix for code scanning alert no. 29: For loop variable changed in body

### DIFF
--- a/rapidyenc/rapidyenc/src/decoder.cc
+++ b/rapidyenc/rapidyenc/src/decoder.cc
@@ -49,7 +49,7 @@ static size_t do_decode_noend_scalar(const unsigned char* src, unsigned char* de
 		} else // treat as YDEC_STATE_CRLF
 			if(es[i] == '.') i++;
 		
-		for(; i < -2; i++) {
+		while (i < -2) {
 			c = es[i];
 			switch(c) {
 				case '\r':
@@ -59,6 +59,7 @@ static size_t do_decode_noend_scalar(const unsigned char* src, unsigned char* de
 						i += 2;
 					// fall-thru
 				case '\n':
+					i++; // Increment i explicitly
 					continue;
 				case '=':
 					c = es[i+1];
@@ -67,6 +68,7 @@ static size_t do_decode_noend_scalar(const unsigned char* src, unsigned char* de
 					continue;
 				default:
 					*p++ = c - 42;
+					i++; // Increment i explicitly
 			}
 		}
 		if(state) *state = YDEC_STATE_NONE;


### PR DESCRIPTION
Potential fix for [https://github.com/go-while/NZBreX/security/code-scanning/29](https://github.com/go-while/NZBreX/security/code-scanning/29)

To fix the issue, the `for` loop should be replaced with a `while` loop. This will make it clear that the loop counter `i` is being modified within the loop body and is not solely controlled by the loop header. The loop condition (`i < -2`) will be moved to the `while` loop condition, and the increment expression (`i++`) will be explicitly handled within the loop body where appropriate.

The changes will involve:
1. Replacing the `for` loop on line 52 with a `while` loop.
2. Ensuring that the logic for incrementing `i` (currently in the `for` loop header) is preserved within the loop body.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
