### PR TITLE
Potential fix for code scanning alert no. 19: For loop variable changed in body

### DIFF
--- a/rapidyenc/rapidyenc/src/decoder.cc
+++ b/rapidyenc/rapidyenc/src/decoder.cc
@@ -222,7 +222,7 @@ static RapidYenc::YencDecoderEnd do_decode_end_scalar(const unsigned char** src,
 	} else // treat as YDEC_STATE_CRLF
 		goto do_decode_endable_scalar_c0;
 	
-	for(; i < -2; i++) {
+	while (i < -2) {
 		c = es[i];
 		switch(c) {
 			case '\r': if(es[i+1] == '\n') {
@@ -283,6 +283,7 @@ static RapidYenc::YencDecoderEnd do_decode_end_scalar(const unsigned char** src,
 			default:
 				*p++ = c - 42;
 		}
+		i++; // Increment `i` at the end of each iteration
 	}
 	if(state) *state = YDEC_STATE_NONE;
 	


### PR DESCRIPTION
Potential fix for [https://github.com/go-while/NZBreX/security/code-scanning/19](https://github.com/go-while/NZBreX/security/code-scanning/19)

To fix the issue, the `for` loop should be replaced with a `while` loop. This will make it explicit that the loop counter `i` can be modified within the loop body, aligning with the intended behavior and improving code clarity. The loop initialization (`i = -(long)len`) and condition (`i < -2`) will be preserved, and the increment expression will be moved into the loop body where it can coexist with other modifications to `i`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
