### PR TITLE
Potential fix for code scanning alert no. 53: Poorly documented large function

### DIFF
--- a/rapidyenc/rapidyenc/crcutil-1.0/code/multiword_128_64_gcc_amd64_sse2.cc
+++ b/rapidyenc/rapidyenc/crcutil-1.0/code/multiword_128_64_gcc_amd64_sse2.cc
@@ -93,20 +93,33 @@ uint128_sse2 GenericCrc<uint128_sse2, uint128_sse2, uint64, 4>::CrcMultiword(
 template<> uint128_sse2
 GenericCrc<uint128_sse2, uint128_sse2, uint64, 4>::CrcMultiwordGccAmd64Sse2(
     const uint8 *src, const uint8 *end, const uint128_sse2 &start) const {
-  __m128i crc0 = start;
-  __m128i crc1;
-  __m128i crc2;
-  __m128i crc3;
-  __m128i crc_carryover;
+  // This function computes a multiword CRC using GCC assembly optimizations
+  // for AMD64 architecture with SSE2 instructions. It processes data in
+  // chunks and uses SIMD registers to perform efficient CRC calculations.
+  // Inputs:
+  //   - src: Pointer to the start of the data buffer.
+  //   - end: Pointer to the end of the data buffer.
+  //   - start: Initial CRC value.
+  // Output:
+  //   - Returns the computed CRC value as a uint128_sse2 object.
 
-  uint64 buf0;
-  uint64 buf1;
-  uint64 buf2;
-  uint64 buf3;
+  __m128i crc0 = start;  // Initialize CRC register with the starting value.
+  __m128i crc1;          // Temporary CRC register for intermediate values.
+  __m128i crc2;          // Temporary CRC register for intermediate values.
+  __m128i crc3;          // Temporary CRC register for intermediate values.
+  __m128i crc_carryover; // Register for carryover CRC calculations.
 
-  uint64 tmp0;
-  uint64 tmp1;
+  uint64 buf0;  // Buffer for data processing.
+  uint64 buf1;  // Buffer for data processing.
+  uint64 buf2;  // Buffer for data processing.
+  uint64 buf3;  // Buffer for data processing.
 
+  uint64 tmp0;  // Temporary variable for intermediate calculations.
+  uint64 tmp1;  // Temporary variable for intermediate calculations.
+
+  // Assembly block for CRC calculation. This block uses SIMD instructions
+  // to process data efficiently. The 'sub' instruction adjusts the end
+  // pointer to align with the processing requirements.
   asm(
     "sub $2*4*8 - 1, %[end]\n"
     "cmpq  %[src], %[end]\n"


### PR DESCRIPTION
Potential fix for [https://github.com/go-while/NZBreX/security/code-scanning/53](https://github.com/go-while/NZBreX/security/code-scanning/53)

To fix the issue, we will add comments to document the purpose and behavior of the function. Specifically:
1. Add a high-level comment at the beginning of the function explaining its purpose, inputs, outputs, and overall logic.
2. Add inline comments throughout the function to explain key operations, especially the assembly code and SIMD instructions.
3. Ensure that the comments are concise but informative, focusing on areas that are likely to be confusing to someone unfamiliar with the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
