### PR TITLE
Potential fix for code scanning alert no. 46: Commented-out code

### DIFF
--- a/rapidyenc/rapidyenc/tool/cli.c
+++ b/rapidyenc/rapidyenc/tool/cli.c
@@ -34,12 +34,12 @@ int main(int argc, char **argv) {
 	}
 #endif
 	
-	FILE* infile = stdin; // fopen("", "rb");
+	FILE* infile = stdin;
 	if(!infile) {
 		fprintf(stderr, "error opening input: %s\n", strerror(errno));
 		return 1;
 	}
-	FILE* outfile = stdout; // fopen("", "rb");
+	FILE* outfile = stdout;
 	if(!outfile) {
 		fprintf(stderr, "error opening output: %s\n", strerror(errno));
 		fclose(infile);


### PR DESCRIPTION
Potential fix for [https://github.com/go-while/NZBreX/security/code-scanning/46](https://github.com/go-while/NZBreX/security/code-scanning/46)

To fix the issue, the commented-out code should either be removed entirely or replaced with a proper comment explaining its purpose. Since there is no indication that the commented-out code serves as documentation or an example, the best approach is to remove it entirely. This will improve code readability and maintainability without altering the functionality of the program.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
