### PR TITLE
Potential fix for code scanning alert no. 47: Long switch case

### DIFF
--- a/rapidyenc/rapidyenc/src/decoder.cc
+++ b/rapidyenc/rapidyenc/src/decoder.cc
@@ -145,6 +145,55 @@ static size_t do_decode_noend_scalar(const unsigned char* src, unsigned char* de
 	return p - dest;
 }
 
+static long handleRawSequence(const unsigned char* es, unsigned char*& p, long i, RapidYenc::YencDecoderState* state, const unsigned char** src, unsigned char** dest) {
+	i += 3;
+	YDEC_CHECK_END(YDEC_STATE_CRLFDT)
+	if (es[i] == '\r') {
+		i++;
+		YDEC_CHECK_END(YDEC_STATE_CRLFDTCR)
+		if (es[i] == '\n') {
+			*src = es + i + 1;
+			*dest = p;
+			*state = YDEC_STATE_CRLF;
+			return YDEC_END_ARTICLE;
+		} else {
+			i--;
+		}
+	} else if (es[i] == '=') {
+		i++;
+		YDEC_CHECK_END(YDEC_STATE_CRLFEQ)
+		if (es[i] == 'y') {
+			*src = es + i + 1;
+			*dest = p;
+			*state = YDEC_STATE_NONE;
+			return YDEC_END_CONTROL;
+		} else {
+			unsigned char c = es[i];
+			*p++ = c - 42 - 64;
+			i -= (c == '\r');
+		}
+	} else {
+		i--;
+	}
+	return i;
+}
+
+static long handleControlSequence(const unsigned char* es, unsigned char*& p, long i, RapidYenc::YencDecoderState* state, const unsigned char** src, unsigned char** dest) {
+	i += 3;
+	YDEC_CHECK_END(YDEC_STATE_CRLFEQ)
+	if (es[i] == 'y') {
+		*src = es + i + 1;
+		*dest = p;
+		*state = YDEC_STATE_NONE;
+		return YDEC_END_CONTROL;
+	} else {
+		unsigned char c = es[i];
+		*p++ = c - 42 - 64;
+		i -= (c == '\r');
+	}
+	return i;
+}
+
 template<bool isRaw>
 static RapidYenc::YencDecoderEnd do_decode_end_scalar(const unsigned char** src, unsigned char** dest, size_t len, RapidYenc::YencDecoderState* state) {
 	using namespace RapidYenc;
@@ -225,54 +274,15 @@ static RapidYenc::YencDecoderEnd do_decode_end_scalar(const unsigned char** src,
 	for(; i < -2; i++) {
 		c = es[i];
 		switch(c) {
-			case '\r': if(es[i+1] == '\n') {
-				if(isRaw && es[i+2] == '.') {
-					// skip past \r\n. sequences
-					i += 3;
-					YDEC_CHECK_END(YDEC_STATE_CRLFDT)
-					// check for end
-					if(es[i] == '\r') {
-						i++;
-						YDEC_CHECK_END(YDEC_STATE_CRLFDTCR)
-						if(es[i] == '\n') {
-							*src = es + i + 1;
-							*dest = p;
-							*state = YDEC_STATE_CRLF;
-							return YDEC_END_ARTICLE;
-						} else i--;
-					} else if(es[i] == '=') {
-						i++;
-						YDEC_CHECK_END(YDEC_STATE_CRLFEQ)
-						if(es[i] == 'y') {
-							*src = es + i + 1;
-							*dest = p;
-							*state = YDEC_STATE_NONE;
-							return YDEC_END_CONTROL;
-						} else {
-							// escape char & continue
-							c = es[i];
-							*p++ = c - 42 - 64;
-							i -= (c == '\r');
-						}
-					} else i--;
-				}
-				else if(es[i+2] == '=') {
-					i += 3;
-					YDEC_CHECK_END(YDEC_STATE_CRLFEQ)
-					if(es[i] == 'y') {
-						// ended
-						*src = es + i + 1;
-						*dest = p;
-						*state = YDEC_STATE_NONE;
-						return YDEC_END_CONTROL;
-					} else {
-						// escape char & continue
-						c = es[i];
-						*p++ = c - 42 - 64;
-						i -= (c == '\r');
+			case '\r': 
+				if (es[i+1] == '\n') {
+					if (isRaw && es[i+2] == '.') {
+						i = handleRawSequence(es, p, i, state, src, dest);
+					} else if (es[i+2] == '=') {
+						i = handleControlSequence(es, p, i, state, src, dest);
 					}
 				}
-			} // fall-thru
+				// fall-thru
 			case '\n':
 				continue;
 			case '=':


### PR DESCRIPTION
Potential fix for [https://github.com/go-while/NZBreX/security/code-scanning/47](https://github.com/go-while/NZBreX/security/code-scanning/47)

To address the issue, the logic within the long case statement (`case '\r':`) should be refactored into separate functions. Each distinct block of functionality within the case should be extracted into a dedicated function with a clear name that describes its purpose. This will reduce the length of the case statement and improve readability.

**Steps to fix:**
1. Identify distinct blocks of logic within the `case '\r':` statement.
2. Create separate functions for each block, ensuring that the functions encapsulate the logic and maintain the same functionality.
3. Replace the code within the `case '\r':` statement with calls to the newly created functions.
4. Ensure that the refactored code is tested to verify that it behaves identically to the original implementation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
