### PR TITLE
Potential fix for code scanning alert no. 48: Declaration hides variable

### DIFF
--- a/rapidyenc/rapidyenc/src/encoder_sse_base.h
+++ b/rapidyenc/rapidyenc/src/encoder_sse_base.h
@@ -691,19 +691,19 @@ HEDLEY_ALWAYS_INLINE void do_encode_sse(int line_size, int* colOffset, const uin
 				maskB = _mm_movemask_epi8(cmpB);
 				
 				mask = (maskB<<16) | maskA;
-				bool manyBitsSet; // don't retain this across loop cycles
+				bool loopManyBitsSet; // don't retain this across loop cycles
 #if defined(__POPCNT__) && !defined(__tune_btver1__)
 				if(use_isa & ISA_FEATURE_POPCNT) {
 					maskBits = popcnt32(mask);
 					outputBytes = maskBits + XMM_SIZE*2;
-					manyBitsSet = maskBits > 1;
+					loopManyBitsSet = maskBits > 1;
 				} else
 #endif
 				{
-					manyBitsSet = (mask & (mask-1)) != 0;
+					loopManyBitsSet = (mask & (mask-1)) != 0;
 				}
 				
-				if (LIKELIHOOD(0.089, manyBitsSet))
+				if (LIKELIHOOD(0.089, loopManyBitsSet))
 					goto _encode_loop_branch_slow;
 				if(_PREFER_BRANCHING && LIKELIHOOD(0.663, !mask))
 					goto _encode_loop_branch_fast_noesc;


### PR DESCRIPTION
Potential fix for [https://github.com/go-while/NZBreX/security/code-scanning/48](https://github.com/go-while/NZBreX/security/code-scanning/48)

To resolve the issue, the inner variable `manyBitsSet` declared on line 694 should be renamed to avoid shadowing the outer variable declared on line 266. This ensures that the two variables are distinct and avoids any confusion about their scopes. The new name should be descriptive and contextually appropriate for its usage within the loop. For example, `loopManyBitsSet` could be used to indicate that the variable is specific to the loop cycle.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
